### PR TITLE
Search functionality: user no longer needs to hit a "search" button to filter results

### DIFF
--- a/app/controllers/costumes_controller.rb
+++ b/app/controllers/costumes_controller.rb
@@ -20,10 +20,6 @@ class CostumesController < ApplicationController
       @costumes = @costumes.where(size: params[:size])
     end
 
-    if params[:available_date].present?
-      @costumes = @costumes.where("available_date >= ?", params[:available_date])
-    end
-
     respond_to do |format|
       format.html # renders the normal index.html.erb
       format.js { render partial: 'costumes/results', locals: { costumes: @costumes } } # renders the partial for AJAX requests

--- a/app/controllers/costumes_controller.rb
+++ b/app/controllers/costumes_controller.rb
@@ -5,20 +5,28 @@ class CostumesController < ApplicationController
   end
 
   def index
-    @costumes = Costume.all
     @costume = Costume.new
-    # These variables are for the search bar functionality
-    @costumes = @costumes.where(category: params[:category]) if params[:category].present?
-    @costumes = @costumes.where(size: params[:size]) if params[:size].present?
-    @costumes = @costumes.where(available_date: params[:available_date]) if params[:available_date].present?
-    # Different from the previous 3 lines so that the user needs to be able to search for any word included in the :name string
-    # I changed from name LIKE to name ILIKE so that the search would be case insensitive
-    @costumes = @costumes.where("name ILIKE ?", "%#{params[:name]}%") if params[:name].present?
+    @costumes = Costume.all
 
-    # Respond differently based on the request format
+    if params[:name].present?
+      @costumes = @costumes.where("name ILIKE ?", "%#{params[:name]}%")
+    end
+
+    if params[:category].present?
+      @costumes = @costumes.where(category: params[:category])
+    end
+
+    if params[:size].present?
+      @costumes = @costumes.where(size: params[:size])
+    end
+
+    if params[:available_date].present?
+      @costumes = @costumes.where("available_date >= ?", params[:available_date])
+    end
+
     respond_to do |format|
-      format.html # Renders the default index.html.erb template
-      format.js { render partial: 'results', locals: { costumes: @costumes } }
+      format.html # renders the normal index.html.erb
+      format.js { render partial: 'costumes/results', locals: { costumes: @costumes } } # renders the partial for AJAX requests
     end
   end
 

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -6,7 +6,7 @@ export default class extends Controller {
 
   connect() {
     console.log("SearchController connected");
-    const form = this.element.querySelector('form');
+    const form = this.element.querySelector('form'); // This variable is  used throughout the code to refer to the search form
     if (form) {
       form.addEventListener('input', this.search.bind(this));
     } else {
@@ -30,7 +30,8 @@ export default class extends Controller {
       return;
     }
 
-    const url = form.action;
+    const url = form.action; // the "form" variable was set  on line #21, form.action retrieves the URL to which the form is set to submit its data
+    // "input->search#search" defines the form action in our _search.html.erb file
     const params = new URLSearchParams(new FormData(form)).toString();
     console.log(`Fetching results from: ${url}?${params}`);
 
@@ -43,22 +44,29 @@ export default class extends Controller {
       .then(response => response.text())
       .then(html => {
         console.log("Received HTML response");
-        this.resultsTarget.innerHTML = html;
+        this.resultsTarget.innerHTML = html; // This ensures that only the "data-search-target="results" div in the index.html.erb file changes
       })
       .catch(error => {
         console.error("Error:", error);
       });
   }
 
-  allFieldsEmpty(form) {
-    const formData = new FormData(form);
-    for (const value of formData.values()) {
-      if (value.trim() !== "") {
+  allFieldsEmpty(form) { // Checking if all fields in a form are empty
+    const formData = new FormData(form); // Creates a FormData object from the given "form" element
+    for (const value of formData.values()) { // This is a loop that iterates over each value in the FormData object and yields the values of the form fields
+      if (value.trim() !== "") { // This removes any whitespace from both ends of the string and checks whether it is empty
         return false;
       }
     }
     return true;
   }
+
+  // Referring to formData.values(), these are the values in formData:
+
+  // name field: " " (string with spaces)
+  // category field: "" (empty string)
+  // size field: "" (empty string)
+  // available_date field: "" (empty string)
 
   loadAllResults(form) {
     const url = form.action;

--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -2,25 +2,77 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="search"
 export default class extends Controller {
-  static targets = ["results"]
+  static targets = ["results", "name", "category", "size", "availableDate"]
 
   connect() {
     console.log("SearchController connected");
+    const form = this.element.querySelector('form');
+    if (form) {
+      form.addEventListener('input', this.search.bind(this));
+    } else {
+      console.error("Form element not found");
+    }
   }
 
   search(event) {
     event.preventDefault();
+    console.log("Search event triggered");
 
-    const url = this.element.action;
-    const params = new URLSearchParams(new FormData(this.element)).toString();
+    const form = event.currentTarget.closest('form');
+    if (!form) {
+      console.error("Form element not found in search event");
+      return;
+    }
 
-    fetch(`${url}?${params}`, {
+    if (this.allFieldsEmpty(form)) {
+      console.log("All fields are empty, fetching all results");
+      this.loadAllResults(form);
+      return;
+    }
+
+    const url = form.action;
+    const params = new URLSearchParams(new FormData(form)).toString();
+    console.log(`Fetching results from: ${url}?${params}`);
+
+    fetch(`${url}?${params}`, { // for example: /costumes?category=superhero
       headers: {
-        "X-Requested-With": "XMLHttpRequest"
+        "X-Requested-With": "XMLHttpRequest", // This header tells the server that the request is an AJAX request
+        "Accept": "text/javascript" // This one tells the server that we expect text or JS as a response, not a full html page
       }
     })
       .then(response => response.text())
       .then(html => {
+        console.log("Received HTML response");
+        this.resultsTarget.innerHTML = html;
+      })
+      .catch(error => {
+        console.error("Error:", error);
+      });
+  }
+
+  allFieldsEmpty(form) {
+    const formData = new FormData(form);
+    for (const value of formData.values()) {
+      if (value.trim() !== "") {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  loadAllResults(form) {
+    const url = form.action;
+    console.log(`Loading all results from: ${url}`);
+
+    fetch(url, {
+      headers: {
+        "X-Requested-With": "XMLHttpRequest",
+        "Accept": "text/javascript"
+      }
+    })
+      .then(response => response.text())
+      .then(html => {
+        console.log("Received HTML response for all results");
         this.resultsTarget.innerHTML = html;
       })
       .catch(error => {

--- a/app/views/costumes/_results.html.erb
+++ b/app/views/costumes/_results.html.erb
@@ -1,5 +1,4 @@
 <div class="row row-cols-1 row-cols-md-3 g-4">
-  <!-- Should be updated dynamically as the user searches -->
   <% @costumes.each do |costume| %>
     <div class="col">
       <div class="card h-100 rounded-4">

--- a/app/views/costumes/_search.html.erb
+++ b/app/views/costumes/_search.html.erb
@@ -1,25 +1,23 @@
-<div data-controller="search">
-  <%= form_with url: costumes_path, method: :get, local: true do %>
+<div>
+  <%= form_with url: costumes_path, method: :get, local: true, data: { action: 'input->search#search' } do %>
     <div class="row my-5">
       <div class="col-md-4 mr-3">
         <%= label_tag :name, "Key Words" %>
-        <%= text_field_tag :name, params[:name], class: "form-control" %>
+        <%= text_field_tag :name, params[:name], class: "form-control", data: { target: 'search.name' } %>
       </div>
       <div class="col mr-3">
         <%= label_tag :category, "Costume Category" %>
-        <%= select_tag :category, options_for_select(Costume.distinct.pluck(:category), params[:category]), include_blank: true, class: "form-control" %>
+        <%= select_tag :category, options_for_select(Costume.distinct.pluck(:category), params[:category]), include_blank: true, class: "form-control", data: { target: 'search.category' } %>
       </div>
       <div class="col mr-3">
         <%= label_tag :size, "Size" %>
-        <%= select_tag :size, options_for_select(Costume.distinct.pluck(:size), params[:size]), include_blank: true, class: "form-control" %>
+        <%= select_tag :size, options_for_select(Costume.distinct.pluck(:size), params[:size]), include_blank: true, class: "form-control", data: { target: 'search.size' } %>
       </div>
       <div class="col mr-3">
         <%= label_tag :available_date, "Available Date" %>
-        <%= date_field_tag :available_date, params[:available_date], class: "form-control" %>
-      </div>
-      <div class="col mr-3 mt-4">
-        <%= submit_tag "Search", class: "btn btn-primary form-control" %>
+        <%= date_field_tag :available_date, params[:available_date], class: "form-control", data: { target: 'search.availableDate' } %>
       </div>
     </div>
   <% end %>
 </div>
+

--- a/app/views/costumes/index.html.erb
+++ b/app/views/costumes/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container">
+<div class="container" data-controller="search">
   <div class="mt-5">
     <h1>Find your costume...</h1>
   </div>
@@ -9,3 +9,4 @@
     <%= render 'costumes/results', costumes: @costumes %>
   </div>
 </div>
+


### PR DESCRIPTION
As the user adds filters to their search, the costumes shown on the page change. There is no longer a "search" button, as it's become redundant. Changes were made to Costumes#index as well as search_controller.js in order to handle the new functionality.

Each change to one of the search field now triggers a JS event, so _search.html.erb was also updated and StimulusJS targets were added to each field (such as search.name, search.category, etc). (Whereas before only the search button triggered an event, no targets were needed)

Costumes#index can very likely be refactored, but I broke down the code as much as I could for our own readability.