### PR TITLE
routing error fix

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -25,7 +25,7 @@
 
               <%= link_to "Add New Costume", new_costume_path, class: "dropdown-item", data: { toggle: "modal", target: "#new-costume" } %>
 
-              <%= link_to "Account Overview", 'users/index', class: "dropdown-item" %>
+              <%= link_to "Account Overview", users_index_path, class: "dropdown-item" %>
 
               <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
 


### PR DESCRIPTION
When clicking the "Account Overview" link in the navbar while on a costume show page, you get a routing error.

I changed the link's path to users_index_path.