### PR TITLE
Changed search bar style to match new wireframe's more closely

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,7 +7,7 @@
 @import "bootstrap";
 @import "font-awesome";
 
-// Import components 
+// Import components
 @import 'components/index';
 @import 'components/avatar';
 @import 'components/form_legend_clear';
@@ -15,6 +15,7 @@
 @import 'components/navbar';
 @import 'components/banner';
 @import 'components/footer';
+@import 'components/search';
 
 // Your CSS partials
 @import "pages/index";

--- a/app/assets/stylesheets/components/_search.scss
+++ b/app/assets/stylesheets/components/_search.scss
@@ -1,0 +1,32 @@
+.search-bar-container {
+  display: flex;
+  border: 1px solid black;
+  border-radius: 25px;
+  overflow: hidden;
+  background-color: white;
+}
+
+.search-field {
+  flex: 1;
+  padding: 10px;
+  position: relative;
+}
+
+.search-field:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: 0;
+  width: 1px;
+  height: 70%;
+  background-color: black;
+  transform: translateY(-50%);
+}
+
+.search-field .form-control {
+  width: 100%;
+  border: none;
+  box-shadow: none;
+  padding-left: 10px;
+  padding-right: 10px;
+}

--- a/app/controllers/costumes_controller.rb
+++ b/app/controllers/costumes_controller.rb
@@ -22,9 +22,13 @@ class CostumesController < ApplicationController
       @costumes = @costumes.where(size: params[:size])
     end
 
-    # if params[:available_date].present?
-    #   @costumes = @costumes.where("available_date >= ?", params[:available_date])
-    # end
+    if params[:start_date].present? && params[:end_date].present?
+      start_date = Date.parse(params[:start_date])
+      end_date = Date.parse(params[:end_date])
+      @costumes = @costumes.reject do |costume|
+        booking_overlap?(costume, start_date, end_date)
+      end
+    end
 
     respond_to do |format|
       format.html # renders the normal index.html.erb
@@ -95,5 +99,11 @@ class CostumesController < ApplicationController
 
   def set_costume
     @costume = Costume.find(params[:id])
+  end
+
+  def booking_overlap?(costume, start_date, end_date)
+    costume.bookings.any? do |booking|
+      (booking.start_date < end_date) && (booking.end_date > start_date)
+    end
   end
 end

--- a/app/views/costumes/_search.html.erb
+++ b/app/views/costumes/_search.html.erb
@@ -13,11 +13,14 @@
             <%= select_tag :size, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:size), params[:size]), prompt: "Size", class: "form-control", data: { target: 'search.size' } %>
           </div>
           <div class="search-field">
-            <%= date_field_tag :available_date, params[:available_date], placeholder: "Available Date", class: "form-control", data: { target: 'search.availableDate' } %>
+              <div data-controller="datepicker">
+              <%= hidden_field_tag :start_date, '', data: { datepicker_target: "startDate" } %>
+              <%= hidden_field_tag :end_date, '', data: { datepicker_target: "endDate" } %>
+              <input type="text" data-datepicker-target="dateRange" class="form-control" placeholder="Select here your dates...">
+            </div>
           </div>
         </div>
       </div>
     </div>
   <% end %>
 </div>
-

--- a/app/views/costumes/_search.html.erb
+++ b/app/views/costumes/_search.html.erb
@@ -7,10 +7,10 @@
             <%= text_field_tag :name, params[:name], placeholder: "Key Words", class: "form-control", data: { target: 'search.name' } %>
           </div>
           <div class="search-field">
-            <%= select_tag :category, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:category), params[:category]), prompt: "Costume Category", class: "form-control", data: { target: 'search.category' } %>
+            <%= select_tag :category, options_for_select(Costume.distinct.pluck(:category), params[:category]), prompt: "Costume Category", class: "form-control", data: { target: 'search.category' } %>
           </div>
           <div class="search-field">
-            <%= select_tag :size, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:size), params[:size]), prompt: "Size", class: "form-control", data: { target: 'search.size' } %>
+            <%= select_tag :size, options_for_select(Costume.distinct.pluck(:size), params[:size]), prompt: "Size", class: "form-control", data: { target: 'search.size' } %>
           </div>
           <div class="search-field">
               <div data-controller="datepicker">

--- a/app/views/costumes/_search.html.erb
+++ b/app/views/costumes/_search.html.erb
@@ -1,22 +1,23 @@
 <div>
   <%= form_with url: costumes_path, method: :get, local: true, data: { action: 'input->search#search' } do %>
     <div class="row my-5">
-      <div class="col-md-4 mr-3">
-        <%= label_tag :name, "Key Words" %>
-        <%= text_field_tag :name, params[:name], placeholder: "What are you looking for?", class: "form-control", data: { target: 'search.name' } %>
-      </div>
-      <div class="col mr-3">
-        <%= label_tag :category, "Costume Category" %>
-        <%= select_tag :category, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:category), params[:category]), prompt: "Select a category", class: "form-control", data: { target: 'search.category' } %>
-      </div>
-      <div class="col mr-3">
-        <%= label_tag :size, "Size" %>
-        <%= select_tag :size, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:size), params[:size]), prompt: "Select a size", class: "form-control", data: { target: 'search.size' } %>
-      </div>
-      <div class="col mr-3">
-        <%= label_tag :available_date, "Available Date" %>
-        <%= date_field_tag :available_date, params[:available_date], class: "form-control", data: { target: 'search.availableDate' } %>
+      <div class="col">
+        <div class="search-bar-container">
+          <div class="search-field">
+            <%= text_field_tag :name, params[:name], placeholder: "Key Words", class: "form-control", data: { target: 'search.name' } %>
+          </div>
+          <div class="search-field">
+            <%= select_tag :category, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:category), params[:category]), prompt: "Costume Category", class: "form-control", data: { target: 'search.category' } %>
+          </div>
+          <div class="search-field">
+            <%= select_tag :size, options_for_select([["View All", "all"]] + Costume.distinct.pluck(:size), params[:size]), prompt: "Size", class: "form-control", data: { target: 'search.size' } %>
+          </div>
+          <div class="search-field">
+            <%= date_field_tag :available_date, params[:available_date], placeholder: "Available Date", class: "form-control", data: { target: 'search.availableDate' } %>
+          </div>
+        </div>
       </div>
     </div>
   <% end %>
 </div>
+


### PR DESCRIPTION
Changed the stye of the search bar, so now it matches the new wireframes more closely. Color and button to be discussed, as the JS functionality updates the results dynamically, which makes a search button redundant. 

![Screenshot 2024-06-08 at 09 57 47](https://github.com/thedavidwenk/costumize/assets/157655310/a397c19f-0062-4a6e-9b19-cbe8e6c72262)
